### PR TITLE
Fix profile screen crash when social links missing

### DIFF
--- a/app/src/main/java/com/labnex/app/activities/ProfileActivity.java
+++ b/app/src/main/java/com/labnex/app/activities/ProfileActivity.java
@@ -99,12 +99,17 @@ public class ProfileActivity extends BaseActivity {
 									}
 								}
 
-								if (!user.getDiscord().isEmpty()
-										|| !user.getLinkedin().isEmpty()
-										|| !user.getTwitter().isEmpty()) {
+								boolean hasDiscord =
+										user.getDiscord() != null && !user.getDiscord().isEmpty();
+								boolean hasLinkedin =
+										user.getLinkedin() != null && !user.getLinkedin().isEmpty();
+								boolean hasTwitter =
+										user.getTwitter() != null && !user.getTwitter().isEmpty();
+
+								if (hasDiscord || hasLinkedin || hasTwitter) {
 									binding.socialInfo.setVisibility(View.VISIBLE);
 
-									if (!user.getDiscord().isEmpty()) {
+									if (hasDiscord) {
 										binding.discord.setVisibility(View.VISIBLE);
 										binding.discord.setText(
 												getString(
@@ -112,12 +117,12 @@ public class ProfileActivity extends BaseActivity {
 														user.getDiscord()));
 									}
 
-									if (!user.getLinkedin().isEmpty()) {
+									if (hasLinkedin) {
 										binding.linkedin.setVisibility(View.VISIBLE);
 										binding.linkedin.setText(user.getLinkedin());
 									}
 
-									if (!user.getTwitter().isEmpty()) {
+									if (hasTwitter) {
 										binding.twitter.setVisibility(View.VISIBLE);
 										binding.twitter.setText(user.getTwitter());
 									}

--- a/app/src/main/java/com/labnex/app/activities/ProfileActivity.java
+++ b/app/src/main/java/com/labnex/app/activities/ProfileActivity.java
@@ -99,17 +99,14 @@ public class ProfileActivity extends BaseActivity {
 									}
 								}
 
-								boolean hasDiscord =
-										user.getDiscord() != null && !user.getDiscord().isEmpty();
-								boolean hasLinkedin =
-										user.getLinkedin() != null && !user.getLinkedin().isEmpty();
-								boolean hasTwitter =
-										user.getTwitter() != null && !user.getTwitter().isEmpty();
-
-								if (hasDiscord || hasLinkedin || hasTwitter) {
+								if (user.getDiscord() != null && !user.getDiscord().isEmpty()
+										|| user.getLinkedin() != null
+												&& !user.getLinkedin().isEmpty()
+										|| user.getTwitter() != null
+												&& !user.getTwitter().isEmpty()) {
 									binding.socialInfo.setVisibility(View.VISIBLE);
 
-									if (hasDiscord) {
+									if (user.getDiscord() != null && !user.getDiscord().isEmpty()) {
 										binding.discord.setVisibility(View.VISIBLE);
 										binding.discord.setText(
 												getString(
@@ -117,12 +114,13 @@ public class ProfileActivity extends BaseActivity {
 														user.getDiscord()));
 									}
 
-									if (hasLinkedin) {
+									if (user.getLinkedin() != null
+											&& !user.getLinkedin().isEmpty()) {
 										binding.linkedin.setVisibility(View.VISIBLE);
 										binding.linkedin.setText(user.getLinkedin());
 									}
 
-									if (hasTwitter) {
+									if (user.getTwitter() != null && !user.getTwitter().isEmpty()) {
 										binding.twitter.setVisibility(View.VISIBLE);
 										binding.twitter.setText(user.getTwitter());
 									}


### PR DESCRIPTION
This fixes a crash when trying to open profiles with missing social info:

```
FATAL EXCEPTION: main
Process: com.labnex.app, PID: 4308
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.isEmpty()' on a null object reference
        at com.labnex.app.activities.ProfileActivity$1.onResponse(ProfileActivity.java:102)
        at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall$1.lambda$onResponse$0$retrofit2-DefaultCallAdapterFactory$ExecutorCallbackCall$1(DefaultCallAdapterFactory.java:89)
        at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall$1$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:240)
        at android.os.Looper.loop(Looper.java:351)
        at android.app.ActivityThread.main(ActivityThread.java:8377)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```