### PR TITLE
Handle links to repos/issues/MRs in (sub)groups

### DIFF
--- a/app/src/main/java/com/labnex/app/activities/DeepLinksActivity.java
+++ b/app/src/main/java/com/labnex/app/activities/DeepLinksActivity.java
@@ -132,15 +132,13 @@ public class DeepLinksActivity extends BaseActivity {
 	private void processDeepLink() {
 		List<String> pathSegments = data.getPathSegments();
 
-		if (pathSegments.size() >= 5) {
-			String sectionType = pathSegments.get(3);
-
-			String userOrGroupName = pathSegments.get(0);
-			String projectName = pathSegments.get(1);
-			String projectPathWithNamespace = userOrGroupName + "/" + projectName;
+		int split = pathSegments.indexOf("-");
+		if (split >= 2) {
+			String sectionType = pathSegments.get(split + 1);
+			String projectPathWithNamespace = String.join("/", pathSegments.subList(0, split));
 
 			if ("issues".equals(sectionType)) {
-				String issueIdStr = pathSegments.get(4);
+				String issueIdStr = pathSegments.get(split + 2);
 				if (issueIdStr != null && issueIdStr.matches("\\d+")) {
 					int issueIid = Integer.parseInt(issueIdStr);
 					goToSpecificIssue(projectPathWithNamespace, issueIid);
@@ -148,7 +146,7 @@ public class DeepLinksActivity extends BaseActivity {
 					goToProjectWithSection(projectPathWithNamespace, "issue");
 				}
 			} else if ("merge_requests".equals(sectionType)) {
-				String mrIdStr = pathSegments.get(4);
+				String mrIdStr = pathSegments.get(split + 2);
 				if (mrIdStr != null && mrIdStr.matches("\\d+")) {
 					int mergeRequestIid = Integer.parseInt(mrIdStr);
 					goToSpecificMergeRequest(projectPathWithNamespace, mergeRequestIid);
@@ -159,9 +157,7 @@ public class DeepLinksActivity extends BaseActivity {
 				goToProject(projectPathWithNamespace);
 			}
 		} else if (pathSegments.size() >= 2) {
-			String userOrGroupName = pathSegments.get(0);
-			String projectName = pathSegments.get(1);
-			String projectPathWithNamespace = userOrGroupName + "/" + projectName;
+			String projectPathWithNamespace = String.join("/", pathSegments);
 			goToProject(projectPathWithNamespace);
 		} else {
 			startActivity(mainIntent);

--- a/app/src/main/java/com/labnex/app/activities/DeepLinksActivity.java
+++ b/app/src/main/java/com/labnex/app/activities/DeepLinksActivity.java
@@ -137,7 +137,7 @@ public class DeepLinksActivity extends BaseActivity {
 			String sectionType = pathSegments.get(split + 1);
 			String projectPathWithNamespace = String.join("/", pathSegments.subList(0, split));
 
-			if ("issues".equals(sectionType)) {
+			if ("issues".equals(sectionType) || "work_items".equals(sectionType)) {
 				String issueIdStr = pathSegments.get(split + 2);
 				if (issueIdStr != null && issueIdStr.matches("\\d+")) {
 					int issueIid = Integer.parseInt(issueIdStr);


### PR DESCRIPTION
This uses the `-` path segment to split the repository path (including owner and zero or more nested groups) from its own resources (issues and merge requests).  If no `-` is present but there are at least two parts, the entire path is parsed as a repository; links to a group will still fall through to the dashboard.

Partially fixes #130 -- ideally we'd also support linking to groups, though there isn't an API method to directly retrieve a group by path like you can with a project.

Also added support for `work_items` (the new name for `issues`) URLs while I'm here.