### PR TITLE
Fix bottom sheet crash from missing `primaryTextColor` in base themes

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -51,6 +51,7 @@
         <item name="colorSurfaceContainerHigh">@color/md_theme_surfaceContainerHigh</item>
         <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
 
+        <item name="primaryTextColor">@color/md_theme_onSurface</item>
         <item name="iconsColor">@color/md_system_default_icons_color</item>
         <item name="textColor">@color/md_system_default_icons_color</item>
         <item name="inputBackgroundColor">@color/md_system_default_input_background_color</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -53,6 +53,7 @@
         <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
         <item name="android:windowAnimationStyle">@style/CustomActivityAnimation</item>
 
+        <item name="primaryTextColor">@color/md_theme_onSurface</item>
         <item name="iconsColor">@color/md_system_default_icons_color</item>
         <item name="textColor">@color/md_system_default_icons_color</item>
         <item name="inputBackgroundColor">@color/md_system_default_input_background_color</item>
@@ -121,6 +122,7 @@
         <item name="android:windowAnimationStyle">@style/CustomActivityAnimation</item>
 
         <item name="isDark">0</item>
+        <item name="primaryTextColor">@color/md_theme_onSurface_light</item>
         <item name="iconsColor">@color/md_light_theme_icons_color</item>
         <item name="textColor">@color/md_light_theme_icons_color</item>
         <item name="inputBackgroundColor">@color/md_light_input_background_color</item>
@@ -189,6 +191,7 @@
         <item name="android:windowAnimationStyle">@style/CustomActivityAnimation</item>
 
         <item name="isDark">1</item>
+        <item name="primaryTextColor">@color/md_theme_onSurface_dark</item>
         <item name="iconsColor">@color/md_dark_theme_icons_color</item>
         <item name="textColor">@color/md_dark_theme_icons_color</item>
         <item name="inputBackgroundColor">@color/md_dark_input_background_color</item>


### PR DESCRIPTION
Hitting the PAT help button crashes when you're not using Dynamic Colors.

The bottom sheet inflates and fails because `primaryTextColor` isn't defined in the
base themes.

The attribute only exists in `AppThemeDynamicColors` (the Android 12+ variant).
`AppTheme`, `AppThemeLight`, and `AppThemeDark` never set it. The `BottomSheetDialogFragment` wraps `AppTheme` with its overlay, so the attribute lookup never reaches the dynamic colors theme even when that's what the
activity is using. 

The `?attr/primaryTextColor` in the layout can't resolve and the whole thing chokes.

To reproduce on current main:
1. Set theme to System default / Light / Dark (not Dynamic Colors)
2. Open any screen with the PAT help button and tap it
3. Observe the crash

The fix just adds `primaryTextColor` to `AppTheme`, `AppThemeLight`, `AppThemeDark` in `values/themes.xml`, and the dark variant in `values-night/themes.xml`, mapped to the appropriate `colorOnSurface` for each theme.

---

P.S. I videcoded this whole thing, cuz that's the only sane way for me to work with java, feel free to just treat this as elaborate issue report and implement your own fix, It did seem to solve the application crash for me on Razer Phone 2 with LineageOS 22.2-20260515-NIGHTLY-aura though and the solution seems to make sense so submitting it as is.

Update: It also seem to made the app significantly faster (from pressing on button and waiting for ~3 seconds to open nearly instantly) and it doesn't crash anymore when i try to open a new issue.